### PR TITLE
test: seach, podcast page, episode page

### DIFF
--- a/cypress/e2e/home-page.cy.ts
+++ b/cypress/e2e/home-page.cy.ts
@@ -15,4 +15,36 @@ describe('Home Page', () => {
       cy.getByTestId('podcast-item').should('have.length', 100)
     })
   })
+
+  context('Search', () => {
+    it('should have a search input', () => {
+      cy.getByTestId('search-input').should('exist')
+    })
+
+    it('should filter the podcasts by search input', () => {
+      cy.getByTestId('search-input').type('joe')
+      cy.getByTestId('podcast-item').should('have.lengthOf.at.least', 1)
+    })
+  })
+
+  context('Podcast Page', ()=> {
+    it('should navigate to podcast page when click on podcast item', () => {
+      cy.getByTestId('podcast-item').first().click()
+      cy.url().should('include', '/podcast/')
+    })
+  })
+
+  context('Podcast Episode Page', ()=> {
+    it('should navigate to podcast episode page when click on episode item', () => {
+      cy.getByTestId('podcast-item').first().click()
+      
+      cy.intercept('GET', 'https://api.allorigins.win/get?url=*').as('getEpisodes')
+
+      cy.wait('@getEpisodes')
+      
+      cy.getByTestId('episode-item').first().click()
+
+      cy.url().should('include', '/episode/')
+    })
+  })
 })

--- a/src/app/podcast/[podcastId]/page.tsx
+++ b/src/app/podcast/[podcastId]/page.tsx
@@ -52,6 +52,7 @@ export default function PodcastView({ params }: { params: { podcastId: string } 
                       <Link
                         href={`/podcast/${params.podcastId}/episode/${episode.trackId}`}
                         className='text-blue-500 hover:underline'
+                        data-testid='episode-item'
                       >
                         {episode.trackName}
                       </Link>

--- a/src/components/filter-podcast.tsx
+++ b/src/components/filter-podcast.tsx
@@ -16,6 +16,7 @@ export default function FilterPodcast() {
       </p>
 
       <Input
+        data-testid='search-input'
         value={search}
         onChange={(event) => setSearch(event.target.value)}
         className='w-full flex-1 sm:w-96 sm:flex-none'


### PR DESCRIPTION
### TL;DR

This Pull Request introduces tests for the search and navigation functionality present in the podcast application.

### What changed?

Test cases have been added to check the following:

- Existence of a search input field
- Filtering of podcasts based on search input
- Navigation to a podcast page when a podcast item is clicked
- Navigation to a podcast episode page when an episode item is clicked

Also, `data-testid` attributes have been added to the search input and episode item elements for facilitating testing.

### How to test?

You can run these tests using the command: `npm run test:e2e`.

### Why make this change?

These tests are important to ensure that the search and navigation functionality works as expected and any future changes don't break these features.


---

